### PR TITLE
Update readme schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ LM-OTS is typically used inside LMS as its one-time signature component, so LMS 
 | 9 | SPHINCS+ (SLH-DSA) | Hash-based | Non-stateful | Stateless hash-based signature scheme. | [sphincs_plus](./sphincs_plus/README.md) | [pqcrypto-sphincsplus](https://crates.io/crates/pqcrypto-sphincsplus) |
 | 10 | SQIsign | Isogeny-based | Non-stateful | Isogeny-based signature scheme from supersingular isogenies. | - | [sqisign](https://crates.io/crates/sqisign)<br>[sqisign-rs](https://crates.io/crates/sqisign-rs)<br>[sqisign.org](https://sqisign.org) |
 | 11 | Mayo | System-of-equations | Non-stateful | Multivariate post-quantum signature scheme (MAYO). | - | [pq-mayo](https://crates.io/crates/pq-mayo) |
-| 12 | CROSS | Code-based | Non-stateful | Code-based post-quantum signature candidate (CROSS). | - | [cross-crypto.com](https://www.cross-crypto.com/cross.html) |
-| 13 | LESS | Code-based | Non-stateful | Code-based post-quantum signature candidate (LESS). | - | [less-project.com](https://www.less-project.com/) |
-| 14 | SQIsignHD | Isogeny-based | Non-stateful | Isogeny-based SQIsign high-dimensional variant (research line). | - | [ePrint 2023/436](https://eprint.iacr.org/2023/436) |
-| 15 | Wave/Wavelet | Code-based | Non-stateful | Code-based post-quantum signature family (Wave/Wavelet). | - | [ePrint 2021/1432](https://eprint.iacr.org/2021/1432) |
+| 12 | CROSS | Code-based | Non-stateful | Code-based post-quantum signature candidate (CROSS). | - | [cross-crypto.com](https://www.cross-crypto.com/cross.html)<br>[C](https://github.com/CROSS-signature/CROSS-implementation) |
+| 13 | LESS | Code-based | Non-stateful | Code-based post-quantum signature candidate (LESS). | - | [less-project.com](https://www.less-project.com/)<br>[C](https://github.com/less-sig/LESS) |
+| 14 | SQIsignHD | Isogeny-based | Non-stateful | Isogeny-based SQIsign high-dimensional variant (research line). | - | No library |
+| 15 | Wave/Wavelet | Code-based | Non-stateful | Code-based post-quantum signature family (Wave/Wavelet). | - | No library |


### PR DESCRIPTION
This PR updated Readme scheme:

- The scheme table was restructured to add Category and Statefulness columns.

- LM-OTS, SPHINCS (original), HORS, and HORST entries were removed; a note was added that LM-OTS is typically used inside LMS.

- Library links were cleaned up:
   1. LMS/HSS use hbs-lms.
   2. XMSS/XMSSMT use RustCrypto XMSS.

- SPHINCS+ uses only pqcrypto-sphincsplus.
- New entries were added: SQIsign, Mayo, CROSS, LESS, SQIsignHD, Wave/Wavelet.

- Latest tweaks:
   1. SQIsign includes sqisign, sqisign-rs, and sqisign.org.
   2. CROSS and LESS include C implementation links.
   3. SQIsignHD and Wave/Wavelet are marked as No library.